### PR TITLE
Replace portable target with netcore451

### DIFF
--- a/src/Microsoft.Framework.OptionsModel/project.json
+++ b/src/Microsoft.Framework.OptionsModel/project.json
@@ -15,7 +15,7 @@
         "System.Threading": "4.0.10-beta-*"
       }
     },
-    ".NETPortable,Version=v4.6,Profile=Profile151": {
+    "netcore451": {
       "frameworkAssemblies": {
         "System.ComponentModel": "",
         "System.Threading": ""


### PR DESCRIPTION
(This will collapse into `core50` when DNX and the Tools for Windows 10 support it.)