### PR TITLE
[Feedback] Use TypeDescriptor instead of Convert

### DIFF
--- a/src/Microsoft.Framework.OptionsModel/ConfigurationBinder.cs
+++ b/src/Microsoft.Framework.OptionsModel/ConfigurationBinder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.Internal;
+using System.ComponentModel;
 
 namespace Microsoft.Framework.OptionsModel
 {
@@ -200,7 +201,12 @@ namespace Microsoft.Framework.OptionsModel
                 }
                 else
                 {
+
+#if DNX451 || DNXCORE50 || NET45
+                    return TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
+#else
                     return Convert.ChangeType(configuration.Get(null), type);
+#endif
                 }
             }
             catch

--- a/src/Microsoft.Framework.OptionsModel/project.json
+++ b/src/Microsoft.Framework.OptionsModel/project.json
@@ -12,7 +12,8 @@
       "dependencies": {
         "System.Reflection.TypeExtensions": "4.0.0-beta-*",
         "System.Runtime.Extensions": "4.0.10-beta-*",
-        "System.Threading": "4.0.10-beta-*"
+        "System.Threading": "4.0.10-beta-*",
+        "System.ComponentModel.TypeConverter":"4.0.0-beta-*" 
       }
     },
     ".NETPortable,Version=v4.5,Profile=Profile7": {

--- a/test/Microsoft.Framework.OptionsModel.Test/OptionsTest.cs
+++ b/test/Microsoft.Framework.OptionsModel.Test/OptionsTest.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Framework.OptionsModel.Tests
             public NestedOptions Nested { get; set; }
             public int Integer { get; set; }
             public bool Boolean { get; set; }
+            public Guid Guid { get; set; }
             public virtual string Virtual { get; set; }
 
             public string PrivateSetter { get; private set; }
@@ -74,12 +75,14 @@ namespace Microsoft.Framework.OptionsModel.Tests
             {
                 {"Integer", "-2"},
                 {"Boolean", "TRUe"},
+                {"Guid", "B2A6B51D-1203-4AC6-88A3-738FEE7E6C0A"},
                 {"Nested:Integer", "11"}
             };
             var config = new Configuration(new MemoryConfigurationSource(dic));
             var options = ConfigurationBinder.Bind<ComplexOptions>(config);
             Assert.True(options.Boolean);
             Assert.Equal(-2, options.Integer);
+            Assert.Equal(Guid.Parse("B2A6B51D-1203-4AC6-88A3-738FEE7E6C0A"), options.Guid);
             Assert.Equal(11, options.Nested.Integer);
         }
 
@@ -90,6 +93,7 @@ namespace Microsoft.Framework.OptionsModel.Tests
             {
                 {"Integer", "-2"},
                 {"Boolean", "TRUe"},
+                {"Guid", "B2A6B51D-1203-4AC6-88A3-738FEE7E6C0A"},
                 {"Nested:Integer", "11"},
                 {"Virtual","Sup"}
             };
@@ -97,6 +101,7 @@ namespace Microsoft.Framework.OptionsModel.Tests
             var options = ConfigurationBinder.Bind<DerivedOptions>(config);
             Assert.True(options.Boolean);
             Assert.Equal(-2, options.Integer);
+            Assert.Equal(Guid.Parse("B2A6B51D-1203-4AC6-88A3-738FEE7E6C0A"), options.Guid);
             Assert.Equal(11, options.Nested.Integer);
             Assert.Equal("Derived:Sup", options.Virtual);
         }


### PR DESCRIPTION
@lodejard @divega @HaoK 

Porting this fix from Identity to use `TypeDescriptor.GetConverter` instead of `Convert` since `Convert` doesn't work for `Guid`. The if-def condition is added since the corresponding package doesn't support PCL. Some questions

- I was unable to get the if-def construct for PCL. I tried `NETPORTABLE`, `PCL` and `.NETPORTABLE,VERSION=V4.5,PROFILE=PROFILE7` with the last one not allowed. Can you point what is correct one ?
- The experience with this change is that, converting Guid is not possible for PCL projects. Do we add workaround for that ? In the discussion I had with @divega we had decided not to add this since PCL should eventually support Core CLR. Let me know if that has changed


