### PR TITLE
Use earliest compatible dependencies

### DIFF
--- a/src/Microsoft.Framework.OptionsModel/project.json
+++ b/src/Microsoft.Framework.OptionsModel/project.json
@@ -15,17 +15,15 @@
     "dnx451": { },
     "dotnet": {
       "dependencies": {
-        "System.ComponentModel": "4.0.1-beta-*",
-        "System.Diagnostics.Debug": "4.0.11-beta-*",
-        "System.Globalization": "4.0.11-beta-*",
-        "System.Linq": "4.0.1-beta-*",
-        "System.Linq.Expressions": "4.0.11-beta-*",
-        "System.Reflection": "4.0.10-*",
-        "System.Reflection.TypeExtensions": "4.0.1-beta-*",
-        "System.Resources.ResourceManager": "4.0.1-beta-*",
-        "System.Runtime": "4.0.21-beta-*",
-        "System.Runtime.Extensions": "4.0.11-beta-*",
-        "System.Threading": "4.0.11-beta-*"
+        "System.Collections": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.0",
+        "System.Globalization": "4.0.0",
+        "System.Linq": "4.0.0",
+        "System.Reflection": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.0",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Threading": "4.0.0"
       }
     }
   }


### PR DESCRIPTION
Enables our packages to work on more platforms with more libraries