### PR TITLE
Add TryConfigure method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ nuget.exe
 *.ipch
 *.sln.ide
 project.lock.json
+.vs/

--- a/Options.sln
+++ b/Options.sln
@@ -1,11 +1,22 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.21722.1
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.OptionsModel", "src\Microsoft.Extensions.OptionsModel\Microsoft.Extensions.OptionsModel.xproj", "{BA4EF3CE-1829-4E0E-8281-BD503FF8A682}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.OptionsModel.Test", "test\Microsoft.Extensions.OptionsModel.Test\Microsoft.Extensions.OptionsModel.Test.xproj", "{16BADE2F-1184-4518-8A70-B68A19D0805B}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Options.ConfigurationExtensions", "src\Microsoft.Extensions.Options.ConfigurationExtensions\Microsoft.Extensions.Options.ConfigurationExtensions.xproj", "{6ACF4BAB-2F09-4DA6-B273-27E4282865EB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{68D94800-FC4C-4E09-82BB-8F19A53ED500}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{4C5EDC5B-06B0-43DC-ACE2-363A825A1FB9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E20F0EF6-A8FE-4099-B307-BC3F1A977304}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		NuGet.config = NuGet.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +32,17 @@ Global
 		{16BADE2F-1184-4518-8A70-B68A19D0805B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16BADE2F-1184-4518-8A70-B68A19D0805B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16BADE2F-1184-4518-8A70-B68A19D0805B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ACF4BAB-2F09-4DA6-B273-27E4282865EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ACF4BAB-2F09-4DA6-B273-27E4282865EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ACF4BAB-2F09-4DA6-B273-27E4282865EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ACF4BAB-2F09-4DA6-B273-27E4282865EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{BA4EF3CE-1829-4E0E-8281-BD503FF8A682} = {68D94800-FC4C-4E09-82BB-8F19A53ED500}
+		{16BADE2F-1184-4518-8A70-B68A19D0805B} = {4C5EDC5B-06B0-43DC-ACE2-363A825A1FB9}
+		{6ACF4BAB-2F09-4DA6-B273-27E4282865EB} = {68D94800-FC4C-4E09-82BB-8F19A53ED500}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "projects": ["src"]
+  "projects": [ "src", "test" ]
 }

--- a/src/Microsoft.Extensions.OptionsModel/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.OptionsModel/OptionsServiceCollectionExtensions.cs
@@ -106,5 +106,15 @@ namespace Microsoft.Extensions.DependencyInjection
             services.ConfigureOptions(new ConfigureOptions<TOptions>(setupAction));
             return services;
         }
+
+        public static IServiceCollection TryConfigure<TOptions>(this IServiceCollection services, Action<TOptions> setupAction)
+            where TOptions : class
+        {
+            if (!services.Any(s => s.ServiceType == typeof(IConfigureOptions<TOptions>)))
+            {
+                services.ConfigureOptions(new ConfigureOptions<TOptions>(setupAction));
+            }
+            return services;
+        }
     }
 }

--- a/test/Microsoft.Extensions.OptionsModel.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.OptionsModel.Test/OptionsTest.cs
@@ -302,5 +302,21 @@ namespace Microsoft.Extensions.OptionsModel.Tests
             Assert.Collection(expectedValues, assertions.ToArray());
         }
 
+       [Fact]
+        public void TryConfigure_ConfiguresOptionsOnce()
+        {
+            // Arrange
+            var services = new ServiceCollection().AddOptions();
+
+            services.TryConfigure<FakeOptions>(o => o.Message = "First");
+            services.TryConfigure<FakeOptions>(o => o.Message = "Second");
+
+            // Act
+            var options = services.BuildServiceProvider().GetService<IOptions<FakeOptions>>().Value;
+
+            // Assert
+           Assert.Equal("First", options.Message);
+           Assert.Equal(1, services.Where(s => s.ServiceType == typeof(IConfigureOptions<FakeOptions>)).Count());
+        }
     }
 }


### PR DESCRIPTION
I'd like to be able to only configure options when they have not been configured already. E.g. when a framework sets default options but they can be overridden by the end-user.