### PR TITLE
Added a convinence wrapper for making IOptions<T> instances

### DIFF
--- a/src/Microsoft.Extensions.Options/Options.cs
+++ b/src/Microsoft.Extensions.Options/Options.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Extensions.Options
+{
+    public static class Options
+    {
+        public static IOptions<TOptions> Create<TOptions>(TOptions options) where TOptions : class, new()
+        {
+            return new OptionsWrapper<TOptions>(options);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsWrapper.cs
+++ b/src/Microsoft.Extensions.Options/OptionsWrapper.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Extensions.Options
+{
+    public class OptionsWrapper<TOptions> : IOptions<TOptions> where TOptions : class, new()
+    {
+        public OptionsWrapper(TOptions options)
+        {
+            Value = options;
+        }
+
+        public TOptions Value { get; }
+    }
+}

--- a/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
@@ -302,5 +302,45 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Collection(expectedValues, assertions.ToArray());
         }
 
+        [Fact]
+        public void Options_StaticCreateCreateMakesOptions()
+        {
+            var options = Options.Create(new FakeOptions
+            {
+                Message = "This is a message"
+            });
+
+            Assert.Equal("This is a message", options.Value.Message);
+        }
+
+        [Fact]
+        public void OptionsWrapper_MakesOptions()
+        {
+            var options = new OptionsWrapper<FakeOptions>(new FakeOptions
+            {
+                Message = "This is a message"
+            });
+
+            Assert.Equal("This is a message", options.Value.Message);
+        }
+
+        [Fact]
+        public void Options_CanOverrideForSpecificTOptions()
+        {
+            var services = new ServiceCollection().AddOptions();
+
+            services.Configure<FakeOptions>(options =>
+            {
+                options.Message = "Initial value";
+            });
+
+            services.AddSingleton(Options.Create(new FakeOptions
+            {
+                Message = "Override"
+            }));
+
+            var sp = services.BuildServiceProvider();
+            Assert.Equal("Override", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
+        }
     }
 }


### PR DESCRIPTION
- Useful for passing poco `TOptions` to APIs that take `IOptions<TOptions>`

#106

/cc @HaoK @divega @DamianEdwards 