### PR TITLE
New Extension for easier configuration

### DIFF
--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
@@ -26,6 +26,22 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfigurationRoot root)
+            where TOptions : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (root == null)
+            {
+                throw new ArgumentNullException(nameof(root));
+            }
+            
+            return Configure<TOptions>(services, root.GetSection(typeof(TOptions).Name));
+        }
+
         public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config, bool trackConfigChanges)
             where TOptions : class
         {


### PR DESCRIPTION
`services.AddOptions().Configure<Data>(Configuration.GetSection("Data"));`

Feels redundant to me, so this extension should allow configuration to look like this instead:

`services.AddOptions().Configure<Data>(Configuration);`