### PR TITLE
Add TryConfigure method

### DIFF
--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
@@ -38,6 +35,23 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
+            return services;
+        }
+
+        public static IServiceCollection TryConfigure<TOptions>(this IServiceCollection services, Action<TOptions> configureOptions)
+            where TOptions : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            services.TryAddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
             return services;
         }
     }

--- a/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
@@ -339,5 +339,22 @@ namespace Microsoft.Extensions.Options.Tests
             var sp = services.BuildServiceProvider();
             Assert.Equal("Override", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
         }
+
+        [Fact]
+        public void TryConfigure_ConfiguresOptionsOnce()
+        {
+            // Arrange
+            var services = new ServiceCollection().AddOptions();
+
+            services.TryConfigure<FakeOptions>(o => o.Message = "First");
+            services.TryConfigure<FakeOptions>(o => o.Message = "Second");
+
+            // Act
+            var options = services.BuildServiceProvider().GetService<IOptions<FakeOptions>>().Value;
+
+            // Assert
+            Assert.Equal("First", options.Message);
+            Assert.Equal(1, services.Count(s => s.ServiceType == typeof(IConfigureOptions<FakeOptions>)));
+        }
     }
 }


### PR DESCRIPTION
Adds a `TryConfigure<T>` method which configures the given configuration action using `TryAddSingleton` so it only can be configured once.