### PR TITLE
IOptions not required in classes using POCO options class

### DIFF
--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class OptionsConfigurationServiceCollectionExtensions
     {
         public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config)
-            where TOptions : class
+            where TOptions : class, new()
         {
             if (services == null)
             {
@@ -23,11 +23,12 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
+            services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
             return services;
         }
 
         public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config, bool trackConfigChanges)
-            where TOptions : class
+            where TOptions : class, new()
         {
             if (services == null)
             {
@@ -40,6 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
+            services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
             if (trackConfigChanges)
             {
                 services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(config));

--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
-            services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
+            services.TryAddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
             return services;
         }
 
@@ -41,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
-            services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
+            services.TryAddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
             if (trackConfigChanges)
             {
                 services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(config));

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         public static IServiceCollection Configure<TOptions>(this IServiceCollection services, Action<TOptions> configureOptions)
-            where TOptions : class
+            where TOptions : class, new()
         {
             if (services == null)
             {
@@ -38,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
+            services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
             return services;
         }
     }

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
-            services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
+            services.TryAddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
             return services;
         }
     }

--- a/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
@@ -339,5 +339,26 @@ namespace Microsoft.Extensions.Options.Tests
             var sp = services.BuildServiceProvider();
             Assert.Equal("Override", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
         }
+
+        [Fact]
+        public void Options_CanGetOptionsFromServiceProvider()
+        {
+            // copy  an existing SetupCallsInOrder test to set things up
+            var services = new ServiceCollection().AddOptions();
+            var dic = new Dictionary<string, string>
+            {
+                {"Message", "!"},
+            };
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
+            var config = builder.Build();
+            services.Configure<FakeOptions>(o => o.Message += "Igetstomped");
+            services.Configure<FakeOptions>(config);
+            services.Configure<FakeOptions>(o => o.Message += "a");
+            services.Configure<FakeOptions>(o => o.Message += "z");
+
+            var options = services.BuildServiceProvider().GetService<FakeOptions>();
+            Assert.NotNull(options);
+            Assert.Equal("!az", options.Message);
+        }
     }
 }


### PR DESCRIPTION
# Problem
Currently, using the` IOptions<TOptions>` pattern requires that the class using the `TOptions` have a dependency on` IOptions<TOptions>` rather than `TOptions`. This forces the class to have a dependency on `Microsoft.Extensions.Options`.  This is not desirable for classes that could be used outside of ASPNET Core classes or apps.

Ideally, the class should only be dependent on the `TOptions` POCO class.

# Solution
By adding a 
``` c#
services.AddSingleton<TOptions>(sp => sp.GetRequiredService<IOptions<TOptions>>().Value);
```
After each
``` c#
services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
```
This allows the `ServiceProvider` to resolve `TOptions` to a correctly initialize instance of `TOption` when used in an ASPNET Core app, and to an manually initialized instance in cases where the ASPNET Core Dependency Injection and Configuration is not used.
`


