### PR TITLE
Options Reborn

### DIFF
--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/ConfigureFromConfigurationOptions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/ConfigureFromConfigurationOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.Options
 {
-    public class ConfigureFromConfigurationOptions<TOptions> : ConfigureOptions<TOptions>
+    public class ConfigureFromConfigurationOptions<TOptions> : ConfigureOptions<TOptions>, IOptionsConfiguration<TOptions>
         where TOptions : class
     {
         public ConfigureFromConfigurationOptions(IConfiguration config)

--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
+            services.AddSingleton<IOptionsConfiguration<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
             return services;
         }
 

--- a/src/Microsoft.Extensions.Options/IOptionsConfiguration.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsConfiguration.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Options
+{
+    public interface IOptionsConfiguration<in TOptions> where TOptions : class
+    {
+        void Configure(TOptions options);
+    }
+}

--- a/src/Microsoft.Extensions.Options/IOptionsInitializer.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsInitializer.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Options
+{
+    public interface IOptionsInitializer<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Initializes the options instance.
+        /// </summary>
+        /// <param name="instance">The options instance.</param>
+        /// <returns></returns>
+        TOptions Initialize(TOptions instance);
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsConfiguration.cs
+++ b/src/Microsoft.Extensions.Options/OptionsConfiguration.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Microsoft.Extensions.Options
 {
-    public class ConfigureOptions<TOptions> : IConfigureOptions<TOptions>, IOptionsConfiguration<TOptions> where TOptions : class
+    public class OptionsConfiguration<TOptions> : IOptionsConfiguration<TOptions> where TOptions : class
     {
-        public ConfigureOptions(Action<TOptions> action)
+        public OptionsConfiguration(Action<TOptions> action)
         {
             if (action == null)
             {

--- a/src/Microsoft.Extensions.Options/OptionsInitializer.cs
+++ b/src/Microsoft.Extensions.Options/OptionsInitializer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Options
+{
+    public class OptionsInitializer<TOptions> : IOptionsInitializer<TOptions> where TOptions : class
+    {
+        private readonly IEnumerable<IConfigureOptions<TOptions>> _configurations;
+
+        public OptionsInitializer(IEnumerable<IConfigureOptions<TOptions>> configurations)
+        {
+            _configurations = configurations;
+        } 
+
+        /// <summary>
+        /// Initializes the options instance.
+        /// </summary>
+        /// <param name="instance">The options instance.</param>
+        /// <returns></returns>
+        public virtual TOptions Initialize(TOptions instance)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+            foreach (var configure in _configurations)
+            {
+                configure.Configure(instance);
+            }
+            return instance;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
@@ -19,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsInitializer<>), typeof(OptionsInitializer<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
             return services;

--- a/test/Microsoft.Extensions.Options.Test/FakeOptions.cs
+++ b/test/Microsoft.Extensions.Options.Test/FakeOptions.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Extensions.Options.Tests
             Message = "";
         }
 
+        public FakeOptions(IOptionsInitializer<FakeOptions> initializer) : this()
+        {
+            initializer.Initialize(this);
+        }
+
         public string Message { get; set; }
     }
 }

--- a/test/Microsoft.Extensions.Options.Test/LegacyTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/LegacyTest.cs
@@ -1,0 +1,345 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options.Tests;
+using Xunit;
+
+namespace Microsoft.Extensions.Options.LegacyTests
+{
+    //IOPTIONS TESTS WILL BE REMOVED
+    public class LegacyTest
+    {
+        public class ComplexOptions
+        {
+            public ComplexOptions()
+            {
+                Nested = new NestedOptions();
+                Virtual = "complex";
+            }
+            public NestedOptions Nested { get; set; }
+            public int Integer { get; set; }
+            public bool Boolean { get; set; }
+            public virtual string Virtual { get; set; }
+
+            public string PrivateSetter { get; private set; }
+            public string ProtectedSetter { get; protected set; }
+            public string InternalSetter { get; internal set; }
+            public static string StaticProperty { get; set; }
+
+            public string ReadOnly
+            {
+                get { return null; }
+            }
+        }
+
+        public class NestedOptions
+        {
+            public int Integer { get; set; }
+        }
+
+        public class DerivedOptions : ComplexOptions
+        {
+            public override string Virtual
+            {
+                get
+                {
+                    return base.Virtual;
+                }
+                set
+                {
+                    base.Virtual = "Derived:" + value;
+                }
+            }
+        }
+
+        public class NullableOptions
+        {
+            public bool? MyNullableBool { get; set; }
+            public int? MyNullableInt { get; set; }
+            public DateTime? MyNullableDateTime { get; set; }
+        }
+
+        public class EnumOptions
+        {
+            public UriKind UriKind { get; set; }
+        }
+
+        [Fact]
+        public void CanReadComplexProperties()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer", "-2"},
+                {"Boolean", "TRUe"},
+                {"Nested:Integer", "11"}
+            };
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
+            var config = builder.Build();
+            var options = new ComplexOptions();
+            ConfigurationBinder.Bind(config, options);
+            Assert.True(options.Boolean);
+            Assert.Equal(-2, options.Integer);
+            Assert.Equal(11, options.Nested.Integer);
+        }
+
+        [Fact]
+        public void CanReadInheritedProperties()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Integer", "-2"},
+                {"Boolean", "TRUe"},
+                {"Nested:Integer", "11"},
+                {"Virtual","Sup"}
+            };
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
+            var config = builder.Build();
+            var options = new DerivedOptions();
+            ConfigurationBinder.Bind(config, options);
+            Assert.True(options.Boolean);
+            Assert.Equal(-2, options.Integer);
+            Assert.Equal(11, options.Nested.Integer);
+            Assert.Equal("Derived:Sup", options.Virtual);
+        }
+
+        [Fact]
+        public void CanReadStaticProperty()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"StaticProperty", "stuff"},
+            };
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
+            var config = builder.Build();
+            var options = new ComplexOptions();
+            ConfigurationBinder.Bind(config, options);
+            Assert.Equal("stuff", ComplexOptions.StaticProperty);
+        }
+
+        [Theory]
+        [InlineData("ReadOnly")]
+        [InlineData("PrivateSetter")]
+        [InlineData("ProtectedSetter")]
+        [InlineData("InternalSetter")]
+        public void ShouldBeIgnoredTests(string property)
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {property, "stuff"},
+            };
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
+            var config = builder.Build();
+            var options = new ComplexOptions();
+            ConfigurationBinder.Bind(config, options);
+            Assert.Null(options.GetType().GetProperty(property).GetValue(options));
+        }
+
+        [Fact]
+        public void SetupCallsInOrder()
+        {
+            var services = new ServiceCollection().AddOptions();
+            var dic = new Dictionary<string, string>
+            {
+                {"Message", "!"},
+            };
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
+            var config = builder.Build();
+            services.Configure<FakeOptions>(o => o.Message += "Igetstomped");
+            services.Configure<FakeOptions>(config);
+            services.Configure<FakeOptions>(o => o.Message += "a");
+            services.Configure<FakeOptions>(o => o.Message += "z");
+
+            var service = services.BuildServiceProvider().GetService<IOptions<FakeOptions>>();
+            Assert.NotNull(service);
+            var options = service.Value;
+            Assert.NotNull(options);
+            Assert.Equal("!az", options.Message);
+        }
+
+        public static TheoryData Configure_GetsNullableOptionsFromConfiguration_Data
+        {
+            get
+            {
+                return new TheoryData<IDictionary<string, string>, IDictionary<string, object>>
+                {
+                    {
+                        new Dictionary<string, string>
+                        {
+                            { nameof(NullableOptions.MyNullableBool), "true" },
+                            { nameof(NullableOptions.MyNullableInt), "1" },
+                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(2015, 1, 1).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern) }
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { nameof(NullableOptions.MyNullableBool), true },
+                            { nameof(NullableOptions.MyNullableInt), 1 },
+                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(2015, 1, 1) }
+                        }
+                    },
+                    {
+                        new Dictionary<string, string>
+                        {
+                            { nameof(NullableOptions.MyNullableBool), "false" },
+                            { nameof(NullableOptions.MyNullableInt), "-1" },
+                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(1995, 12, 31).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern) }
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { nameof(NullableOptions.MyNullableBool), false },
+                            { nameof(NullableOptions.MyNullableInt), -1 },
+                            { nameof(NullableOptions.MyNullableDateTime), new DateTime(1995, 12, 31) }
+                        }
+                    },
+                    {
+                        new Dictionary<string, string>
+                        {
+                            { nameof(NullableOptions.MyNullableBool), null },
+                            { nameof(NullableOptions.MyNullableInt), null },
+                            { nameof(NullableOptions.MyNullableDateTime), null }
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { nameof(NullableOptions.MyNullableBool), null },
+                            { nameof(NullableOptions.MyNullableInt), null },
+                            { nameof(NullableOptions.MyNullableDateTime), null }
+                        }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Configure_GetsNullableOptionsFromConfiguration_Data))]
+        public void Configure_GetsNullableOptionsFromConfiguration(
+            IDictionary<string, string> configValues,
+            IDictionary<string, object> expectedValues)
+        {
+            // Arrange
+            var services = new ServiceCollection().AddOptions();
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(configValues);
+            var config = builder.Build();
+            services.Configure<NullableOptions>(config);
+
+            // Act
+            var options = services.BuildServiceProvider().GetService<IOptions<NullableOptions>>().Value;
+
+            // Assert
+            var optionsProps = options.GetType().GetProperties().ToDictionary(p => p.Name);
+            var assertions = expectedValues
+                .Select(_ => new Action<KeyValuePair<string, object>>(kvp =>
+                    Assert.Equal(kvp.Value, optionsProps[kvp.Key].GetValue(options))));
+            Assert.Collection(expectedValues, assertions.ToArray());
+        }
+
+        public static TheoryData Configure_GetsEnumOptionsFromConfiguration_Data
+        {
+            get
+            {
+                return new TheoryData<IDictionary<string, string>, IDictionary<string, object>>
+                {
+                    {
+                        new Dictionary<string, string>
+                        {
+                            { nameof(EnumOptions.UriKind), (UriKind.Absolute).ToString() },
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { nameof(EnumOptions.UriKind), UriKind.Absolute },
+                        }
+                    },
+                    {
+                        new Dictionary<string, string>
+                        {
+                            { nameof(EnumOptions.UriKind), ((int)UriKind.Absolute).ToString() },
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { nameof(EnumOptions.UriKind), UriKind.Absolute },
+                        }
+                    },
+                    {
+                        new Dictionary<string, string>
+                        {
+                            { nameof(EnumOptions.UriKind), null },
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { nameof(EnumOptions.UriKind), UriKind.RelativeOrAbsolute },  //default enum, since not overridden by configuration
+                        }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Configure_GetsEnumOptionsFromConfiguration_Data))]
+        public void Configure_GetsEnumOptionsFromConfiguration(
+            IDictionary<string, string> configValues,
+            IDictionary<string, object> expectedValues)
+        {
+            // Arrange
+            var services = new ServiceCollection().AddOptions();
+            var builder = new ConfigurationBuilder().AddInMemoryCollection(configValues);
+            var config = builder.Build();
+            services.Configure<EnumOptions>(config);
+
+            // Act
+            var options = services.BuildServiceProvider().GetService<IOptions<EnumOptions>>().Value;
+
+            // Assert
+            var optionsProps = options.GetType().GetProperties().ToDictionary(p => p.Name);
+            var assertions = expectedValues
+                .Select(_ => new Action<KeyValuePair<string, object>>(kvp =>
+                    Assert.Equal(kvp.Value, optionsProps[kvp.Key].GetValue(options))));
+            Assert.Collection(expectedValues, assertions.ToArray());
+        }
+
+        [Fact]
+        public void Options_StaticCreateCreateMakesOptions()
+        {
+            var options = Options.Create(new FakeOptions
+            {
+                Message = "This is a message"
+            });
+
+            Assert.Equal("This is a message", options.Value.Message);
+        }
+
+        [Fact]
+        public void OptionsWrapper_MakesOptions()
+        {
+            var options = new OptionsWrapper<FakeOptions>(new FakeOptions
+            {
+                Message = "This is a message"
+            });
+
+            Assert.Equal("This is a message", options.Value.Message);
+        }
+
+        [Fact]
+        public void Options_CanOverrideForSpecificTOptions()
+        {
+            var services = new ServiceCollection().AddOptions();
+
+            services.Configure<FakeOptions>(options =>
+            {
+                options.Message = "Initial value";
+            });
+
+            services.AddSingleton(Options.Create(new FakeOptions
+            {
+                Message = "Override"
+            }));
+
+            var sp = services.BuildServiceProvider();
+            Assert.Equal("Override", sp.GetRequiredService<IOptions<FakeOptions>>().Value.Message);
+        }
+    }
+}


### PR DESCRIPTION
- New API portion of https://github.com/aspnet/Options/issues/122, removal of IOptions will come later
- IConfigureOptions => IOptionsConfiguration
- IOptionsInitializer service instead of IEnumerableConfigureOptionsMegaLongTypeName
- Hybrid where old ConfigureOptions implements both new and old to keep existing code working

Example:
```
        public class EnumOptions
             public EnumOptions() { }
             public EnumOptions(IOptionsInitializer<EnumOptions> initializer) : this()
             {
                 initializer.Initialize(this);
             }
```
cc @divega @davidfowl @lodejard 
