### PR TITLE
Restore Order to the World!

### DIFF
--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsConfigurationServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsConfigurationServiceCollectionExtensions.cs
@@ -22,6 +22,21 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config)
             where TOptions : class
         {
+            return services.Configure<TOptions>(config, Options.Options.NextDefaultConfigureOptionsOrder() + Options.Options.DefaultConfigurationBindOrderOffset);
+        }
+
+        /// <summary>
+        /// Registers a configuration instance which TOptions will bind against.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of options being configured.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="config">The configuration being bound.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        /// <param name="order">The order used to determine when the options binding will be executed.</param>
+        /// <returns></returns>
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config, int order)
+            where TOptions : class
+        {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
@@ -32,7 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config) { Order = order });
         }
     }
 }

--- a/src/Microsoft.Extensions.Options/ConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Options/ConfigureOptions.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Extensions.Options
         }
 
         /// <summary>
+        /// Used to determine the order which IConfigureOptions will be run.
+        /// </summary>
+        public int Order { get; set; }
+
+        /// <summary>
         /// The configuration action.
         /// </summary>
         public Action<TOptions> Action { get; }

--- a/src/Microsoft.Extensions.Options/IConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Options/IConfigureOptions.cs
@@ -14,5 +14,10 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         /// <param name="options">The options instance to configure.</param>
         void Configure(TOptions options);
+
+        /// <summary>
+        /// Used to determine the order which IConfigureOptions will be run.
+        /// </summary>
+        int Order { get; }
     }
 }

--- a/src/Microsoft.Extensions.Options/Options.cs
+++ b/src/Microsoft.Extensions.Options/Options.cs
@@ -6,6 +6,30 @@
     public static class Options
     {
         /// <summary>
+        /// The order which will be used for the next call to Configure
+        /// </summary>
+        public static int DefaultConfigureOptionsOrder;
+
+        /// <summary>
+        /// The value added to DefaultConfigureOptionsOrder when Configure is called.
+        /// </summary>
+        public static int DefaultConfigureOptionsOrderIncrement = 10;
+
+        /// <summary>
+        /// Default offset used by Configure which binds against ConfigurationSections.
+        /// </summary>
+        public static int DefaultConfigurationBindOrderOffset = -25000;
+
+        /// <summary>
+        /// Returns DefaultConfigureOptionsOrder and increments it by DefaultConfigureOptionsOrderIncrement.
+        /// </summary>
+        /// <returns></returns>
+        public static int NextDefaultConfigureOptionsOrder()
+        {
+            return DefaultConfigureOptionsOrder += DefaultConfigureOptionsOrderIncrement;
+        }
+
+        /// <summary>
         /// Creates a wrapper around an instance of TOptions to return itself as an IOptions.
         /// </summary>
         /// <typeparam name="TOptions"></typeparam>

--- a/src/Microsoft.Extensions.Options/Options.cs
+++ b/src/Microsoft.Extensions.Options/Options.cs
@@ -6,30 +6,6 @@
     public static class Options
     {
         /// <summary>
-        /// The order which will be used for the next call to Configure
-        /// </summary>
-        public static int DefaultConfigureOptionsOrder;
-
-        /// <summary>
-        /// The value added to DefaultConfigureOptionsOrder when Configure is called.
-        /// </summary>
-        public static int DefaultConfigureOptionsOrderIncrement = 10;
-
-        /// <summary>
-        /// Default offset used by Configure which binds against ConfigurationSections.
-        /// </summary>
-        public static int DefaultConfigurationBindOrderOffset = -25000;
-
-        /// <summary>
-        /// Returns DefaultConfigureOptionsOrder and increments it by DefaultConfigureOptionsOrderIncrement.
-        /// </summary>
-        /// <returns></returns>
-        public static int NextDefaultConfigureOptionsOrder()
-        {
-            return DefaultConfigureOptionsOrder += DefaultConfigureOptionsOrderIncrement;
-        }
-
-        /// <summary>
         /// Creates a wrapper around an instance of TOptions to return itself as an IOptions.
         /// </summary>
         /// <typeparam name="TOptions"></typeparam>

--- a/src/Microsoft.Extensions.Options/OptionsCache.cs
+++ b/src/Microsoft.Extensions.Options/OptionsCache.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Microsoft.Extensions.Options
@@ -26,7 +27,8 @@ namespace Microsoft.Extensions.Options
             var result = new TOptions();
             if (_setups != null)
             {
-                foreach (var setup in _setups)
+                var ordered = _setups.OrderBy(setup => setup.Order);
+                foreach (var setup in ordered)
                 {
                     setup.Configure(result);
                 }

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -38,6 +38,20 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection Configure<TOptions>(this IServiceCollection services, Action<TOptions> configureOptions)
             where TOptions : class
         {
+            return services.Configure(configureOptions, Options.Options.NextDefaultConfigureOptionsOrder());
+        }
+
+        /// <summary>
+        /// Registers an action used to configure a particular type of options.
+        /// </summary>
+        /// <typeparam name="TOptions">The options type to be configured.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="configureOptions">The action used to configure the options.</param>
+        /// <param name="order">The order which is used to decide when configureOptions will be run.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, Action<TOptions> configureOptions, int order)
+            where TOptions : class
+        {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
@@ -48,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configureOptions));
             }
 
-            services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
+            services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions) { Order = order });
             return services;
         }
     }

--- a/test/Microsoft.Extensions.Options.Test/OptionsMonitorTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsMonitorTest.cs
@@ -224,6 +224,8 @@ namespace Microsoft.Extensions.Options.Tests
                 _test = test;
             }
 
+            public int Order { get; set; }
+
             public void Configure(FakeOptions options)
             {
                 _test.SetupInvokeCount++;

--- a/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
@@ -140,53 +140,43 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
-        public void ConfigureWithOrderDoesNotIncrementsDefaultOrder()
-        {
-            var services = new ServiceCollection().AddOptions();
-            var initial = Options.DefaultConfigureOptionsOrder;
-            services.Configure<FakeOptions>(o => o.Message += "z", 1000);
-            Assert.Equal(initial, Options.DefaultConfigureOptionsOrder);
-        }
-
-        [Fact]
-        public void ConfigureIncrementsDefaultOrder()
-        {
-            var services = new ServiceCollection().AddOptions();
-            var initial = Options.DefaultConfigureOptionsOrder;
-            Assert.Equal(10, Options.DefaultConfigureOptionsOrderIncrement);
-
-            services.Configure<FakeOptions>(o => o.Message += "z");
-            Assert.Equal(initial+10, Options.DefaultConfigureOptionsOrder);
-            services.Configure<FakeOptions>(o => o.Message += "z");
-            Assert.Equal(initial+20, Options.DefaultConfigureOptionsOrder);
-        }
-
-        [Fact]
         public void SetupCallsInOrder()
         {
             var services = new ServiceCollection().AddOptions();
             var dic = new Dictionary<string, string>
             {
+                {"Message", "-"},
+            };
+            var config = new ConfigurationBuilder().AddInMemoryCollection(dic).Build();
+            var dic2 = new Dictionary<string, string>
+            {
                 {"Message", "!"},
             };
-            var builder = new ConfigurationBuilder().AddInMemoryCollection(dic);
-            var config = builder.Build();
+            var config2 = new ConfigurationBuilder().AddInMemoryCollection(dic2).Build();
+
             // Run before configuration
-            services.Configure<FakeOptions>(o => o.Message += "Igetstomped", Options.DefaultConfigureOptionsOrder+Options.DefaultConfigurationBindOrderOffset-1);
+            services.Configure<FakeOptions>(o => o.Message += "Igetstomped", -25001);
             services.Configure<FakeOptions>(config);
-            services.Configure<FakeOptions>(o => o.Message += "z", 100000);
-            services.Configure<FakeOptions>(o => o.Message += "c", Options.DefaultConfigureOptionsOrder+11);
-            services.Configure<FakeOptions>(o => o.Message += "y", 1000);
-            services.Configure<FakeOptions>(o => o.Message += "e", Options.DefaultConfigureOptionsOrder+21);
+            services.Configure<FakeOptions>(config2, -9999); // Config 2
             services.Configure<FakeOptions>(o => o.Message += "a", -100);
-            services.Configure<FakeOptions>(o => o.Message += "b");
-            services.Configure<FakeOptions>(o => o.Message += "d");
+            services.Configure<FakeOptions>(o => o.Message += "b"); // order at -90
+            services.Configure<FakeOptions>(o => o.Message += "c", -89);
+            services.Configure<FakeOptions>(o => o.Message += "d"); // order at -79
+            services.Configure<FakeOptions>(o => o.Message += "e", -74);
+            services.Configure<FakeOptions>(o => o.Message += "f"); // order at -64
+            services.Configure<FakeOptions>(o => o.Message += "g", -63);
+            services.Configure<FakeOptions>(o => o.Message += "h", 1);
+            services.Configure<FakeOptions>(o => o.Message += "i"); // order at 11
+            services.Configure<FakeOptions>(o => o.Message += "j", 12);
+
+            services.Configure<FakeOptions>(o => o.Message += "z", 100000);
+            services.Configure<FakeOptions>(o => o.Message += "y", 1000);
 
             var service = services.BuildServiceProvider().GetService<IOptions<FakeOptions>>();
             Assert.NotNull(service);
             var options = service.Value;
             Assert.NotNull(options);
-            Assert.Equal("!abcdeyz", options.Message);
+            Assert.Equal("!abcdefghijyz", options.Message);
         }
 
         public static TheoryData Configure_GetsNullableOptionsFromConfiguration_Data

--- a/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
@@ -143,22 +143,22 @@ namespace Microsoft.Extensions.Options.Tests
         public void ConfigureWithOrderDoesNotIncrementsDefaultOrder()
         {
             var services = new ServiceCollection().AddOptions();
+            var initial = Options.DefaultConfigureOptionsOrder;
             services.Configure<FakeOptions>(o => o.Message += "z", 1000);
-            Assert.Equal(0, Options.DefaultConfigureOptionsOrder);
-            Assert.Equal(10, Options.DefaultConfigureOptionsOrderIncrement);
+            Assert.Equal(initial, Options.DefaultConfigureOptionsOrder);
         }
 
         [Fact]
         public void ConfigureIncrementsDefaultOrder()
         {
             var services = new ServiceCollection().AddOptions();
-            Assert.Equal(0, Options.DefaultConfigureOptionsOrder);
+            var initial = Options.DefaultConfigureOptionsOrder;
             Assert.Equal(10, Options.DefaultConfigureOptionsOrderIncrement);
 
             services.Configure<FakeOptions>(o => o.Message += "z");
-            Assert.Equal(10, Options.DefaultConfigureOptionsOrder);
+            Assert.Equal(initial+10, Options.DefaultConfigureOptionsOrder);
             services.Configure<FakeOptions>(o => o.Message += "z");
-            Assert.Equal(20, Options.DefaultConfigureOptionsOrder);
+            Assert.Equal(initial+20, Options.DefaultConfigureOptionsOrder);
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsTest.cs
@@ -176,16 +176,17 @@ namespace Microsoft.Extensions.Options.Tests
             services.Configure<FakeOptions>(config);
             services.Configure<FakeOptions>(o => o.Message += "z", 100000);
             services.Configure<FakeOptions>(o => o.Message += "c", Options.DefaultConfigureOptionsOrder+11);
-            services.Configure<FakeOptions>(o => o.Message += "y", Options.DefaultConfigureOptionsOrder+21);
+            services.Configure<FakeOptions>(o => o.Message += "y", 1000);
+            services.Configure<FakeOptions>(o => o.Message += "e", Options.DefaultConfigureOptionsOrder+21);
             services.Configure<FakeOptions>(o => o.Message += "a", -100);
             services.Configure<FakeOptions>(o => o.Message += "b");
-            services.Configure<FakeOptions>(o => o.Message += "x");
+            services.Configure<FakeOptions>(o => o.Message += "d");
 
             var service = services.BuildServiceProvider().GetService<IOptions<FakeOptions>>();
             Assert.NotNull(service);
             var options = service.Value;
             Assert.NotNull(options);
-            Assert.Equal("!abcxyz", options.Message);
+            Assert.Equal("!abcdeyz", options.Message);
         }
 
         public static TheoryData Configure_GetsNullableOptionsFromConfiguration_Data


### PR DESCRIPTION
Fixes https://github.com/aspnet/Options/issues/150

Currently is doing a basic auto-incrementing order logic instead of inspecting the service collection for each call to Configure. This means Configures without order specified will be clustered together.  

This lets users have a bit more granular control if they want to put overrides with large orders, and preserves call ordering when order is never specified.
