### PR TITLE
Options Reloaded

### DIFF
--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/ConfigurationChangeTokenSource.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/ConfigurationChangeTokenSource.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Creates IChangeTokens so that IOptionsMonitor gets notified when IConfiguration changes.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public class ConfigurationChangeTokenSource<TOptions> : IOptionsChangeTokenSource<TOptions>
+    {
+        private IConfiguration _config;
+
+        /// <summary>
+        /// Constructor taking the IConfiguration instance to watch.
+        /// </summary>
+        /// <param name="config">The configuration instance.</param>
+        public ConfigurationChangeTokenSource(IConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+            _config = config;
+        }
+
+        /// <summary>
+        /// Returns the reloadToken from IConfiguration.
+        /// </summary>
+        /// <returns></returns>
+        public IChangeToken GetChangeToken()
+        {
+            return _config.GetReloadToken();
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsConfigurationServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options.ConfigurationExtensions/OptionsConfigurationServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(config));
             }
 
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(config));
             return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
         }
     }

--- a/src/Microsoft.Extensions.Options/IOptionsChangeTokenSource.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsChangeTokenSource.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Used to fetch IChangeTokens used for tracking options changes.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public interface IOptionsChangeTokenSource<out TOptions>
+    {
+        /// <summary>
+        /// Returns a IChangeToken which can be used to register a change notification callback.
+        /// </summary>
+        /// <returns></returns>
+        IChangeToken GetChangeToken();
+    }
+}

--- a/src/Microsoft.Extensions.Options/IOptionsSnapshot.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsSnapshot.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Used to access the value of TOptions for the lifetime of a request.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public interface IOptionsSnapshot<out TOptions>
+    {
+        /// <summary>
+        /// Returns the value of the TOptions which will be computed once
+        /// </summary>
+        /// <returns></returns>
+        TOptions Value { get; }
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsMonitor.cs
+++ b/src/Microsoft.Extensions.Options/OptionsMonitor.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of IOptionsMonitor.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public class OptionsMonitor<TOptions> : IOptionsMonitor<TOptions> where TOptions : class, new()
+    {
+        private OptionsCache<TOptions> _optionsCache;
+        private readonly IEnumerable<IConfigureOptions<TOptions>> _setups;
+        private readonly IEnumerable<IOptionsChangeTokenSource<TOptions>> _sources;
+        private List<Action<TOptions>> _listeners = new List<Action<TOptions>>();
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="setups">The configuration actions to run on an options instance.</param>
+        /// <param name="sources">The sources used to listen for changes to the options instance.</param>
+        public OptionsMonitor(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IOptionsChangeTokenSource<TOptions>> sources)
+        {
+            _sources = sources;
+            _setups = setups;
+            _optionsCache = new OptionsCache<TOptions>(setups);
+
+            foreach (var source in _sources)
+            {
+                ChangeToken.OnChange(
+                    () => source.GetChangeToken(),
+                    () => InvokeChanged());
+            }
+        }
+
+        private void InvokeChanged()
+        {
+            _optionsCache = new OptionsCache<TOptions>(_setups);
+            foreach (var listener in _listeners)
+            {
+                listener?.Invoke(_optionsCache.Value);
+            }
+        }
+
+        /// <summary>
+        /// The present value of the options.
+        /// </summary>
+        public TOptions CurrentValue
+        {
+            get
+            {
+                return _optionsCache.Value;
+            }
+        }
+
+        /// <summary>
+        /// Registers a single listener which will be called when the options value has changed.  Subsequent calls will override
+        /// the previous listener.
+        /// </summary>
+        /// <param name="listener"></param>
+        /// <returns></returns>
+        public IDisposable OnChange(Action<TOptions> listener)
+        {
+            var disposable = new ChangeTrackerDisposable(_listeners, listener);
+            _listeners.Add(listener);
+            return disposable;
+        }
+
+        internal class ChangeTrackerDisposable : IDisposable
+        {
+            private readonly Action<TOptions> _originalListener;
+            private readonly IList<Action<TOptions>> _listeners;
+
+            public ChangeTrackerDisposable(IList<Action<TOptions>> listeners, Action<TOptions> listener)
+            {
+                _originalListener = listener;
+                _listeners = listeners;
+            }
+
+            public void Dispose()
+            {
+                _listeners.Remove(_originalListener);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(OptionsManager<>)));
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
+            services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsSnapshot<>)));
             return services;
         }
 

--- a/src/Microsoft.Extensions.Options/OptionsSnapshot.cs
+++ b/src/Microsoft.Extensions.Options/OptionsSnapshot.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of IOptionsSnapshot.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public class OptionsSnapshot<TOptions> : IOptionsSnapshot<TOptions> where TOptions : class, new()
+    {
+        private TOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="monitor">The monitor to fetch the options value from.</param>
+        public OptionsSnapshot(IOptionsMonitor<TOptions> monitor)
+        {
+            _options = monitor.CurrentValue;
+        }
+
+        /// <summary>
+        /// The configured options instance.
+        /// </summary>
+        public virtual TOptions Value
+        {
+            get
+            {
+                return _options;
+            }
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Options.Test/OptionsMonitorTest.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsMonitorTest.cs
@@ -2,187 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 
-namespace Microsoft.Extensions.Options
-{
-    using System;
-    using System.Collections.Generic;
-
-    /// <summary>
-    /// Used to fetch IChangeTokens.
-    /// </summary>
-    /// <typeparam name="TOptions"></typeparam>
-    public interface IOptionsChangeTokenSource<out TOptions>
-    {
-        /// <summary>
-        /// Returns a IChangeToken which can be used to register a change notification callback.
-        /// </summary>
-        /// <returns></returns>
-        IChangeToken GetChangeToken();
-    }
-
-    internal class ChangeTrackerDisposable : IDisposable
-    {
-        public List<IDisposable> Disposables { get; } = new List<IDisposable>();
-
-        public void Dispose()
-        {
-            foreach (var d in Disposables)
-            {
-                d?.Dispose();
-            }
-            Disposables.Clear();
-        }
-    }
-
-    /// <summary>
-    /// Implementation of IOptionsMonitor.
-    /// </summary>
-    /// <typeparam name="TOptions"></typeparam>
-    public class OptionsMonitor<TOptions> : IOptionsMonitor<TOptions> where TOptions : class, new()
-    {
-        private OptionsCache<TOptions> _optionsCache;
-        private readonly IEnumerable<IConfigureOptions<TOptions>> _setups;
-        private readonly IEnumerable<IOptionsChangeTokenSource<TOptions>> _sources;
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="setups">The configuration actions to run on an options instance.</param>
-        /// <param name="sources">The sources used to listen for changes to the options instance.</param>
-        public OptionsMonitor(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IOptionsChangeTokenSource<TOptions>> sources)
-        {
-            _sources = sources;
-            _setups = setups;
-            _optionsCache = new OptionsCache<TOptions>(setups);
-        }
-
-        /// <inheritdoc></inheritdoc>
-        public TOptions CurrentValue
-        {
-            get
-            {
-                return _optionsCache.Value;
-            }
-        }
-
-        /// <inheritdoc></inheritdoc>
-        public IDisposable OnChange(Action<TOptions> listener)
-        {
-            var disposable = new ChangeTrackerDisposable();
-            foreach (var source in _sources)
-            {
-
-                Action<object> callback = null;
-                IDisposable previousSubscription = null;
-                callback = (s) =>
-                {
-                    // The order here is important. We need to take the token and then apply our changes BEFORE
-                    // registering. This prevents us from possible having two change updates to process concurrently.
-                    //
-                    // If the token changes after we take the token, then we'll process the update immediately upon
-                    // registering the callback.
-                    var token = source.GetChangeToken();
-
-                    // Recompute the options before calling the watchers
-                    _optionsCache = new OptionsCache<TOptions>(_setups);
-                    listener(_optionsCache.Value);
-
-                    // Remove the old callback after its been fired
-                    var nextSubscription = token.RegisterChangeCallback(callback, s);
-                    disposable.Disposables.Add(nextSubscription);
-                    disposable.Disposables.Remove(previousSubscription);
-                    previousSubscription = nextSubscription;
-                };
-
-                previousSubscription = source.GetChangeToken().RegisterChangeCallback(callback, state: null);
-                disposable.Disposables.Add(previousSubscription);
-            }
-            return disposable;
-        }
-    }
-
-    /// <summary>
-    /// Creates IChangeTokens so that IOptionsMonitor gets notified when IConfiguration changes.
-    /// </summary>
-    /// <typeparam name="TOptions"></typeparam>
-    public class ConfigurationChangeTokenSource<TOptions> : IOptionsChangeTokenSource<TOptions>
-    {
-        private IConfiguration _config;
-
-        /// <summary>
-        /// Constructor taking the IConfiguration instance to watch.
-        /// </summary>
-        /// <param name="config">The configuration instance.</param>
-        public ConfigurationChangeTokenSource(IConfiguration config)
-        {
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-            _config = config;
-        }
-
-        /// <summary>
-        /// Returns the reloadToken from IConfiguration.
-        /// </summary>
-        /// <returns></returns>
-        public IChangeToken GetChangeToken()
-        {
-            return _config.GetReloadToken();
-        }
-    }
-}
-
-namespace Microsoft.Extensions.DependencyInjection
-{
-    /// <summary>
-    /// Extension methods for adding configuration related options services to the DI container.
-    /// </summary>
-    public static class OptionsMonitorServiceCollectionExtensions
-    {
-        /// <summary>
-        /// Registers a configuration instance which TOptions will bind against.
-        /// </summary>
-        /// <typeparam name="TOptions">The type of options being configured.</typeparam>
-        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
-        /// <param name="config">The configuration being bound.</param>
-        /// <param name="trackConfigChanges">If true, registers an change token source for use by an IOptionsMonitor.</param>
-        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config, bool trackConfigChanges)
-            where TOptions : class
-        {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-
-            services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureFromConfigurationOptions<TOptions>(config));
-            if (trackConfigChanges)
-            {
-                services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(config));
-            }
-            return services;
-        }
-
-        public static IServiceCollection AddOptionsMonitor(this IServiceCollection services)
-        {
-            services.AddOptions().TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
-            return services;
-        }
-    }
-}
 namespace Microsoft.Extensions.Options.Tests
 {
     public class OptionsMonitorTest
@@ -256,7 +82,7 @@ namespace Microsoft.Extensions.Options.Tests
         [Fact]
         public void CanWatchOptions()
         {
-            var services = new ServiceCollection().AddOptionsMonitor();
+            var services = new ServiceCollection().AddOptions();
 
             services.AddSingleton<IConfigureOptions<FakeOptions>>(new CountIncrement(this));
             var changeToken = new FakeChangeToken();
@@ -279,9 +105,62 @@ namespace Microsoft.Extensions.Options.Tests
         }
 
         [Fact]
+        public void CanWatchOptionsWithMultipleSourcesAndCallbacks()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.AddSingleton<IConfigureOptions<FakeOptions>>(new CountIncrement(this));
+            var changeToken = new FakeChangeToken();
+            var tracker = new FakeSource(changeToken);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(tracker);
+            var changeToken2 = new FakeChangeToken();
+            var tracker2 = new FakeSource(changeToken2);
+            services.AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(tracker2);
+
+            var sp = services.BuildServiceProvider();
+
+            var monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+            Assert.NotNull(monitor);
+            Assert.Equal("1", monitor.CurrentValue.Message);
+
+            string updatedMessage = null;
+            string updatedMessage2 = null;
+            var cleanup = monitor.OnChange(o => updatedMessage = o.Message);
+            var cleanup2 = monitor.OnChange(o => updatedMessage2 = o.Message);
+            changeToken.InvokeChangeCallback();
+            Assert.Equal("2", updatedMessage);
+            Assert.Equal("2", updatedMessage2);
+
+            // Verify old watch is changed too
+            Assert.Equal("2", monitor.CurrentValue.Message);
+
+            changeToken2.InvokeChangeCallback();
+            Assert.Equal("3", updatedMessage);
+            Assert.Equal("3", updatedMessage2);
+
+            // Verify old watch is changed too
+            Assert.Equal("3", monitor.CurrentValue.Message);
+
+            cleanup.Dispose();
+            changeToken.InvokeChangeCallback();
+            changeToken2.InvokeChangeCallback();
+
+            // Verify only the second message changed
+            Assert.Equal("3", updatedMessage);
+            Assert.Equal("5", updatedMessage2);
+
+            cleanup2.Dispose();
+            changeToken.InvokeChangeCallback();
+            changeToken2.InvokeChangeCallback();
+
+            // Verify no message changed
+            Assert.Equal("3", updatedMessage);
+            Assert.Equal("5", updatedMessage2);
+        }
+
+        [Fact]
         public void CanWatchOptionsWithMultipleSources()
         {
-            var services = new ServiceCollection().AddOptionsMonitor();
+            var services = new ServiceCollection().AddOptions();
             services.AddSingleton<IConfigureOptions<FakeOptions>>(new CountIncrement(this));
             var changeToken = new FakeChangeToken();
             var tracker = new FakeSource(changeToken);
@@ -316,7 +195,6 @@ namespace Microsoft.Extensions.Options.Tests
 
             // Verify messages aren't changed
             Assert.Equal("3", updatedMessage);
-            Assert.Equal("3", monitor.CurrentValue.Message);
         }
 
         [Fact]
@@ -324,9 +202,9 @@ namespace Microsoft.Extensions.Options.Tests
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
 
-            var services = new ServiceCollection().AddOptionsMonitor();
+            var services = new ServiceCollection().AddOptions();
             services.AddSingleton<IConfigureOptions<FakeOptions>>(new CountIncrement(this));
-            services.Configure<FakeOptions>(config, trackConfigChanges: true);
+            services.Configure<FakeOptions>(config);
 
             var sp = services.BuildServiceProvider();
 
@@ -336,7 +214,7 @@ namespace Microsoft.Extensions.Options.Tests
 
             string updatedMessage = null;
 
-            var cleanup = monitor.OnChange(o => updatedMessage = o.Message) as ChangeTrackerDisposable;
+            var cleanup = monitor.OnChange(o => updatedMessage = o.Message);
 
             config.Reload();
             Assert.Equal("2", updatedMessage);
@@ -344,22 +222,22 @@ namespace Microsoft.Extensions.Options.Tests
             // Verify old watch is changed too
             Assert.Equal("2", monitor.CurrentValue.Message);
 
-            Assert.Equal(1, cleanup.Disposables.Count);
-
             cleanup.Dispose();
             config.Reload();
 
-            // Verify things don't change after the subscription is disposed
+            // Verify our message don't change after the subscription is disposed
             Assert.Equal("2", updatedMessage);
-            Assert.Equal("2", monitor.CurrentValue.Message);
+
+            // But the monitor still gets updated with the latest current value
+            Assert.Equal("3", monitor.CurrentValue.Message);
         }
 
-        public class Controller : IDisposable
+        public class ControllerWithMonitor : IDisposable
         {
             IDisposable _watcher;
             FakeOptions _options;
 
-            public Controller(IOptionsMonitor<FakeOptions> watcher)
+            public ControllerWithMonitor(IOptionsMonitor<FakeOptions> watcher)
             {
                 _watcher = watcher.OnChange(o => _options = o);
             }
@@ -372,19 +250,31 @@ namespace Microsoft.Extensions.Options.Tests
             public string Message => _options?.Message;
         }
 
+        public class ControllerWithSnapshot
+        {
+            FakeOptions _options;
+
+            public ControllerWithSnapshot(IOptionsSnapshot<FakeOptions> snap)
+            {
+                _options = snap.Value;
+            }
+
+            public string Message => _options?.Message;
+        }
+
         [Fact]
         public void ControllerCanWatchOptionsThatTrackConfigChanges()
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
 
-            var services = new ServiceCollection().AddOptionsMonitor();
+            var services = new ServiceCollection().AddOptions();
             services.AddSingleton<IConfigureOptions<FakeOptions>>(new CountIncrement(this));
-            services.AddTransient<Controller, Controller>();
-            services.Configure<FakeOptions>(config, trackConfigChanges: true);
+            services.AddTransient<ControllerWithMonitor, ControllerWithMonitor>();
+            services.Configure<FakeOptions>(config);
 
             var sp = services.BuildServiceProvider();
 
-            var controller = sp.GetRequiredService<Controller>();
+            var controller = sp.GetRequiredService<ControllerWithMonitor>();
             Assert.Null(controller.Message);
 
             config.Reload();
@@ -392,6 +282,39 @@ namespace Microsoft.Extensions.Options.Tests
 
             config.Reload();
             Assert.Equal("2", controller.Message);
+        }
+
+        [Fact]
+        public void SnapshotOptionsDoNotChangeEvenWhenMonitorChanges()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+            var services = new ServiceCollection().AddOptions();
+            services.AddSingleton<IConfigureOptions<FakeOptions>>(new CountIncrement(this));
+            services.Configure<FakeOptions>(config);
+
+            var sp = services.BuildServiceProvider();
+
+            var monitor = sp.GetRequiredService<IOptionsMonitor<FakeOptions>>();
+            var snapshot = sp.GetRequiredService<IOptionsSnapshot<FakeOptions>>();
+
+            var options = monitor.CurrentValue;
+            Assert.Equal("1", options.Message);
+            Assert.Equal(options, snapshot.Value);
+
+            var token = config.GetReloadToken();
+
+            config.Reload();
+
+            Assert.NotEqual(monitor.CurrentValue, snapshot.Value);
+            Assert.Equal("2", monitor.CurrentValue.Message);
+            Assert.Equal("1", snapshot.Value.Message);
+
+            config.Reload();
+
+            Assert.NotEqual(monitor.CurrentValue, snapshot.Value);
+            Assert.Equal("3", monitor.CurrentValue.Message);
+            Assert.Equal("1", snapshot.Value.Message);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/Options/issues/145#issuecomment-250020098

Initial shape with basic tests (want to add a few more)

Few points to consider:
- The feature is always 'on', any time Configure(IConfiguration) is called, we hook up the notifications (no way to disable)
- We could have the current OptionsManager implement both IOptions and IOptionsSnapshot (we'd register the class twice, singleton for IOptions, and Scoped for Snapshot, felt too weird so I didn't go that route, and copied the class, since its tiny)
- Support multiple listeners in OptionsMonitor.OnChange or not?  Basically subsequent calls could either add additional callbacks, or override the first callback.  I did the more complicated list of callbacks, but I'd be glad to kill this.
- (Found a nasty bug with CurrentValue in the old implementation where it wouldn't get updated if no one ever called OnChange) 