### PR TITLE
Options 2.0 - Add support for named options, validation, and caching

### DIFF
--- a/src/Microsoft.Extensions.Options/ConfigureNamedOptions.cs
+++ b/src/Microsoft.Extensions.Options/ConfigureNamedOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of IConfigureNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public class ConfigureNamedOptions<TOptions> : IConfigureNamedOptions<TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="action">The action to register.</param>
+        public ConfigureNamedOptions(string name, Action<TOptions> action)
+        {
+            Name = name;
+            Action = action;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions> Action { get; }
+
+        /// <summary>
+        /// Invokes the registered configure Action if the name matches.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="options"></param>
+        public virtual void Configure(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/IConfigureNamedOptions.cs
+++ b/src/Microsoft.Extensions.Options/IConfigureNamedOptions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Options
+{
+
+    /// <summary>
+    /// Represents something that configures the TOptions type.
+    /// </summary>
+    /// <typeparam name="TOptions"></typeparam>
+    public interface IConfigureNamedOptions<in TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// The name of the instance to configure.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Invoked to configure a TOptions instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance being configured.</param>
+        /// <param name="options">The options instance to configure.</param>
+        void Configure(string name, TOptions options);
+    }
+}

--- a/src/Microsoft.Extensions.Options/IConfigureNamedOptions.cs
+++ b/src/Microsoft.Extensions.Options/IConfigureNamedOptions.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Extensions.Options
     public interface IConfigureNamedOptions<in TOptions> where TOptions : class
     {
         /// <summary>
-        /// The name of the instance to configure.
-        /// </summary>
-        string Name { get; }
-
-        /// <summary>
         /// Invoked to configure a TOptions instance.
         /// </summary>
         /// <param name="name">The name of the options instance being configured.</param>

--- a/src/Microsoft.Extensions.Options/IOptionsCache.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsCache.cs
@@ -1,17 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Extensions.Options
 {
     /// <summary>
-    /// Used to create TOptions instances.
+    /// Used to cache TOptions instances.
     /// </summary>
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    public interface IOptionsFactory<TOptions> where TOptions : class, new()
+    public interface IOptionsCache<TOptions> where TOptions : class
     {
-        /// <summary>
-        /// Returns a configured TOptions instance with the given name.
-        /// </summary>
-        TOptions Create(string name);
+        TOptions GetOrAdd(string name, Func<TOptions> createOptions);
+
+        bool TryAdd(string name, TOptions options);
+
+        bool TryRemove(string name);
+
+        // Do we need a Clear all?
     }
 }

--- a/src/Microsoft.Extensions.Options/IOptionsFactory.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsFactory.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Used to retreive configured and validated TOptions instances.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public interface IOptionsFactory<out TOptions> where TOptions : class, new()
+    {
+        /// <summary>
+        /// Returns a configured and validated TOptions instance with the given name.
+        /// </summary>
+        TOptions Get(string name);
+    }
+}

--- a/src/Microsoft.Extensions.Options/IOptionsService.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsService.cs
@@ -4,14 +4,18 @@
 namespace Microsoft.Extensions.Options
 {
     /// <summary>
-    /// Used to create TOptions instances.
+    /// Used to retreive configured and validated TOptions instances.
     /// </summary>
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    public interface IOptionsFactory<TOptions> where TOptions : class, new()
+    public interface IOptionsService<TOptions> where TOptions : class, new()
     {
         /// <summary>
-        /// Returns a configured TOptions instance with the given name.
+        /// Returns a configured and validated TOptions instance with the given name.
         /// </summary>
-        TOptions Create(string name);
+        TOptions Get(string name);
+
+        void Add(string name, TOptions options);
+
+        bool Remove(string name);
     }
 }

--- a/src/Microsoft.Extensions.Options/IOptionsValidator.cs
+++ b/src/Microsoft.Extensions.Options/IOptionsValidator.cs
@@ -4,14 +4,14 @@
 namespace Microsoft.Extensions.Options
 {
     /// <summary>
-    /// Used to create TOptions instances.
+    /// Used to validate TOptions instances.
     /// </summary>
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    public interface IOptionsFactory<TOptions> where TOptions : class, new()
+    public interface IOptionsValidator<TOptions> where TOptions : class, new()
     {
         /// <summary>
-        /// Returns a configured TOptions instance with the given name.
+        /// Validates the options instance.
         /// </summary>
-        TOptions Create(string name);
+        void Validate(string name, TOptions options);
     }
 }

--- a/src/Microsoft.Extensions.Options/IValidateNamedOptions.cs
+++ b/src/Microsoft.Extensions.Options/IValidateNamedOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Represents something that validate the TOptions type.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public interface IValidateNamedOptions<in TOptions> where TOptions : class
+    {
+        /// <summary>
+        /// The name of the options instance to validate.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Invoked to validate a TOptions instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance to validate.</param>
+        void Validate(string name, TOptions options);
+    }
+}

--- a/src/Microsoft.Extensions.Options/LegacyOptionsCache.cs
+++ b/src/Microsoft.Extensions.Options/LegacyOptionsCache.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.Extensions.Options
+{
+    internal class LegacyOptionsCache<TOptions> where TOptions : class, new()
+    {
+        private readonly Func<TOptions> _createCache;
+        private object _cacheLock = new object();
+        private bool _cacheInitialized;
+        private TOptions _options;
+        private IEnumerable<IConfigureOptions<TOptions>> _setups;
+
+        public LegacyOptionsCache(IEnumerable<IConfigureOptions<TOptions>> setups)
+        {
+            _setups = setups;
+            _createCache = CreateOptions;
+        }
+
+        private TOptions CreateOptions()
+        {
+            var result = new TOptions();
+            if (_setups != null)
+            {
+                foreach (var setup in _setups)
+                {
+                    setup.Configure(result);
+                }
+            }
+            return result;
+        }
+
+        public virtual TOptions Value
+        {
+            get
+            {
+                return LazyInitializer.EnsureInitialized(
+                    ref _options,
+                    ref _cacheInitialized,
+                    ref _cacheLock,
+                    _createCache);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/Microsoft.Extensions.Options.csproj
+++ b/src/Microsoft.Extensions.Options/Microsoft.Extensions.Options.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Provides a strongly typed way of specifying and accessing settings using dependency injection.</Description>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;options</PackageTags>
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="System.ComponentModel" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Collections.Concurrent" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Extensions.Options/Microsoft.Extensions.Options.csproj
+++ b/src/Microsoft.Extensions.Options/Microsoft.Extensions.Options.csproj
@@ -13,8 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="System.ComponentModel" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Collections.Concurrent" Version="$(CoreFxVersion)" />
-  </ItemGroup>
+    <PackageReference Include="System.ComponentModel" Version="$(CoreFxVersion)" />  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Extensions.Options/OptionsCache.cs
+++ b/src/Microsoft.Extensions.Options/OptionsCache.cs
@@ -1,49 +1,65 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Extensions.Options
 {
-    internal class OptionsCache<TOptions> where TOptions : class, new()
+    /// <summary>
+    /// Used to cache TOptions instances.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public class OptionsCache<TOptions> : IOptionsCache<TOptions> where TOptions : class
     {
-        private readonly Func<TOptions> _createCache;
-        private object _cacheLock = new object();
-        private bool _cacheInitialized;
-        private TOptions _options;
-        private IEnumerable<IConfigureOptions<TOptions>> _setups;
+        private readonly ConcurrentDictionary<string, Lazy<TOptions>> _cache = new ConcurrentDictionary<string, Lazy<TOptions>>(StringComparer.Ordinal);
 
-        public OptionsCache(IEnumerable<IConfigureOptions<TOptions>> setups)
+        public virtual TOptions GetOrAdd(string name, Func<TOptions> createOptions)
         {
-            _setups = setups;
-            _createCache = CreateOptions;
-        }
-
-        private TOptions CreateOptions()
-        {
-            var result = new TOptions();
-            if (_setups != null)
+            if (name == null)
             {
-                foreach (var setup in _setups)
-                {
-                    setup.Configure(result);
-                }
+                throw new ArgumentNullException(nameof(name));
             }
-            return result;
+            if (createOptions == null)
+            {
+                throw new ArgumentNullException(nameof(createOptions));
+            }
+            return _cache.GetOrAdd(name, new Lazy<TOptions>(createOptions)).Value;
         }
 
-        public virtual TOptions Value
+        /// <summary>
+        /// Tries to adds a new option to the cache, will return false if the name already exists.
+        /// </summary>
+        /// <param name="name">The name of the options instance.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>Whether anything was added.</returns>
+        public virtual bool TryAdd(string name, TOptions options)
         {
-            get
+            if (name == null)
             {
-                return LazyInitializer.EnsureInitialized(
-                    ref _options,
-                    ref _cacheInitialized,
-                    ref _cacheLock,
-                    _createCache);
+                throw new ArgumentNullException(nameof(name));
             }
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            return _cache.TryAdd(name, new Lazy<TOptions>(() => options));
         }
+
+        /// <summary>
+        /// Try to remove an options instance.
+        /// </summary>
+        /// <param name="name">The name of the options instance.</param>
+        /// <returns>Whether anything was removed.</returns>
+        public virtual bool TryRemove(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            return _cache.TryRemove(name, out var ignored);
+        }
+
+        // Do we need a Clear all?
     }
 }

--- a/src/Microsoft.Extensions.Options/OptionsFactory.cs
+++ b/src/Microsoft.Extensions.Options/OptionsFactory.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of IOptionsFactory.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public class OptionsFactory<TOptions> : IOptionsFactory<TOptions> where TOptions : class, new()
+    {
+        private readonly Dictionary<string, TOptions> _cache = new Dictionary<string, TOptions>();
+        private readonly IEnumerable<IConfigureNamedOptions<TOptions>> _setups;
+        private readonly IEnumerable<IValidateNamedOptions<TOptions>> _checks;
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Initializes a new instance with the specified options configurations.
+        /// </summary>
+        /// <param name="setups">The configuration actions to run.</param>
+        /// <param name="checks">The validation actions to run.</param>
+        public OptionsFactory(IEnumerable<IConfigureNamedOptions<TOptions>> setups, IEnumerable<IValidateNamedOptions<TOptions>> checks)
+        {
+            _setups = setups;
+            _checks = checks;
+        }
+
+        public TOptions Get(string name)
+        {
+            if (_cache.ContainsKey(name))
+            {
+                return _cache[name];
+            }
+            else
+            {
+                lock (_lock)
+                {
+                    if (_cache.ContainsKey(name))
+                    {
+                        return _cache[name];
+                    }
+
+                    var value = new TOptions();
+                    foreach (var setup in _setups)
+                    {
+                        setup.Configure(name, value);
+                    }
+                    foreach (var check in _checks)
+                    {
+                        check.Validate(name, value);
+                    }
+                    _cache[name] = value;
+                    return value;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsFactory.cs
+++ b/src/Microsoft.Extensions.Options/OptionsFactory.cs
@@ -11,50 +11,25 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
     public class OptionsFactory<TOptions> : IOptionsFactory<TOptions> where TOptions : class, new()
     {
-        private readonly Dictionary<string, TOptions> _cache = new Dictionary<string, TOptions>();
         private readonly IEnumerable<IConfigureNamedOptions<TOptions>> _setups;
-        private readonly IEnumerable<IValidateNamedOptions<TOptions>> _checks;
-        private readonly object _lock = new object();
 
         /// <summary>
         /// Initializes a new instance with the specified options configurations.
         /// </summary>
         /// <param name="setups">The configuration actions to run.</param>
-        /// <param name="checks">The validation actions to run.</param>
-        public OptionsFactory(IEnumerable<IConfigureNamedOptions<TOptions>> setups, IEnumerable<IValidateNamedOptions<TOptions>> checks)
+        public OptionsFactory(IEnumerable<IConfigureNamedOptions<TOptions>> setups)
         {
             _setups = setups;
-            _checks = checks;
         }
 
-        public TOptions Get(string name)
+        public TOptions Create(string name)
         {
-            if (_cache.ContainsKey(name))
+            var options = new TOptions();
+            foreach (var setup in _setups)
             {
-                return _cache[name];
+                setup.Configure(name, options);
             }
-            else
-            {
-                lock (_lock)
-                {
-                    if (_cache.ContainsKey(name))
-                    {
-                        return _cache[name];
-                    }
-
-                    var value = new TOptions();
-                    foreach (var setup in _setups)
-                    {
-                        setup.Configure(name, value);
-                    }
-                    foreach (var check in _checks)
-                    {
-                        check.Validate(name, value);
-                    }
-                    _cache[name] = value;
-                    return value;
-                }
-            }
+            return options;
         }
     }
 }

--- a/src/Microsoft.Extensions.Options/OptionsManager.cs
+++ b/src/Microsoft.Extensions.Options/OptionsManager.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions"></typeparam>
     public class OptionsManager<TOptions> : IOptions<TOptions>, IOptionsSnapshot<TOptions> where TOptions : class, new()
     {
-        private OptionsCache<TOptions> _optionsCache;
+        private LegacyOptionsCache<TOptions> _optionsCache;
 
         /// <summary>
         /// Initializes a new instance with the specified options configurations.
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Options
         /// <param name="setups">The configuration actions to run.</param>
         public OptionsManager(IEnumerable<IConfigureOptions<TOptions>> setups)
         {
-            _optionsCache = new OptionsCache<TOptions>(setups);
+            _optionsCache = new LegacyOptionsCache<TOptions>(setups);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Options/OptionsMonitor.cs
+++ b/src/Microsoft.Extensions.Options/OptionsMonitor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions"></typeparam>
     public class OptionsMonitor<TOptions> : IOptionsMonitor<TOptions> where TOptions : class, new()
     {
-        private OptionsCache<TOptions> _optionsCache;
+        private LegacyOptionsCache<TOptions> _optionsCache;
         private readonly IEnumerable<IConfigureOptions<TOptions>> _setups;
         private readonly IEnumerable<IOptionsChangeTokenSource<TOptions>> _sources;
         private List<Action<TOptions>> _listeners = new List<Action<TOptions>>();
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Options
         {
             _sources = sources;
             _setups = setups;
-            _optionsCache = new OptionsCache<TOptions>(setups);
+            _optionsCache = new LegacyOptionsCache<TOptions>(setups);
 
             foreach (var source in _sources)
             {
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Options
 
         private void InvokeChanged()
         {
-            _optionsCache = new OptionsCache<TOptions>(_setups);
+            _optionsCache = new LegacyOptionsCache<TOptions>(_setups);
             foreach (var listener in _listeners)
             {
                 listener?.Invoke(_optionsCache.Value);

--- a/src/Microsoft.Extensions.Options/OptionsService.cs
+++ b/src/Microsoft.Extensions.Options/OptionsService.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of IOptionsFactory.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public class OptionsService<TOptions> : IOptionsService<TOptions> where TOptions : class, new()
+    {
+        private readonly IOptionsCache<TOptions> _cache;
+        private readonly IOptionsFactory<TOptions> _factory;
+        private readonly IOptionsValidator<TOptions> _validator;
+
+        /// <summary>
+        /// Initializes a new instance with the specified options configurations.
+        /// </summary>
+        /// <param name="cache">The cache to use.</param>
+        /// <param name="factory">The factory to use to create options.</param>
+        /// <param name="validator">The validator used to validate options.</param>
+        public OptionsService(IOptionsCache<TOptions> cache, IOptionsFactory<TOptions> factory, IOptionsValidator<TOptions> validator)
+        {
+            _cache = cache;
+            _factory = factory;
+            _validator = validator;
+        }
+
+        public virtual void Add(string name, TOptions options)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            if (!_cache.TryAdd(name, options))
+            {
+                throw new InvalidOperationException("An option named {name} already exists.");
+            }
+        }
+
+        public virtual TOptions Get(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            return _cache.GetOrAdd(name, () =>
+            {
+                var options = _factory.Create(name);
+                _validator.Validate(name, options);
+                return options;
+            });
+        }
+
+        public virtual bool Remove(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            return _cache.TryRemove(name);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
-            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsFactory<>), typeof(OptionsFactory<>)));
+            services.TryAdd(ServiceDescriptor.Transient(typeof(IOptionsService<>), typeof(OptionsService<>)));
+            services.TryAdd(ServiceDescriptor.Transient(typeof(IOptionsFactory<>), typeof(OptionsFactory<>)));
+            services.TryAdd(ServiceDescriptor.Transient(typeof(IOptionsValidator<>), typeof(OptionsValidator<>)));
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsCache<>), typeof(OptionsCache<>)));
             return services;
         }
 

--- a/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Options/OptionsServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsFactory<>), typeof(OptionsFactory<>)));
             return services;
         }
 
@@ -51,6 +52,102 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureOptions<TOptions>(configureOptions));
+            return services;
+        }
+
+        /// <summary>
+        /// Registers an action used to configure a particular type of options.
+        /// </summary>
+        /// <typeparam name="TOptions">The options type to be configured.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="name">The name of the options instance.</param>
+        /// <param name="configureOptions">The action used to configure the options.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string name, Action<TOptions> configureOptions)
+            where TOptions : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            services.AddSingleton<IConfigureNamedOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, configureOptions));
+            return services;
+        }
+
+        public static IServiceCollection ConfigureAll<TOptions>(this IServiceCollection services, Action<TOptions> configureOptions)
+            where TOptions : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            // REVIEW: should this ignore the non named options?  ConfigureAllNamed?
+            services.Configure(configureOptions);
+            services.AddSingleton<IConfigureNamedOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name: null, action: configureOptions));
+            return services;
+        }
+
+        /// <summary>
+        /// Registers an action used to validate options with a specific name.
+        /// </summary>
+        /// <typeparam name="TOptions">The options type to be configured.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="name">The name of the options instance.</param>
+        /// <param name="validateOptions">The action used to validate the options.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection Validate<TOptions>(this IServiceCollection services, string name, Action<TOptions> validateOptions)
+            where TOptions : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (validateOptions == null)
+            {
+                throw new ArgumentNullException(nameof(validateOptions));
+            }
+
+            services.AddSingleton<IValidateNamedOptions<TOptions>>(new ValidateNamedOptions<TOptions>(name, validateOptions));
+            return services;
+        }
+
+        public static IServiceCollection ValidateAll<TOptions>(this IServiceCollection services, Action<TOptions> validateOptions)
+            where TOptions : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (validateOptions == null)
+            {
+                throw new ArgumentNullException(nameof(validateOptions));
+            }
+
+            services.AddSingleton<IValidateNamedOptions<TOptions>>(new ValidateNamedOptions<TOptions>(name: null, action: validateOptions));
             return services;
         }
     }

--- a/src/Microsoft.Extensions.Options/OptionsValidator.cs
+++ b/src/Microsoft.Extensions.Options/OptionsValidator.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of IOptionsValidator.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public class OptionsValidator<TOptions> : IOptionsValidator<TOptions> where TOptions : class, new()
+    {
+        private readonly IEnumerable<IValidateNamedOptions<TOptions>> _checks;
+
+        /// <summary>
+        /// Initializes a new instance with the specified options configurations.
+        /// </summary>
+        /// <param name="validations">The validation actions to run.</param>
+        public OptionsValidator(IEnumerable<IValidateNamedOptions<TOptions>> validations)
+        {
+            _checks = validations;
+        }
+
+        public void Validate(string name, TOptions options)
+        {
+            foreach (var check in _checks)
+            {
+                check.Validate(name, options);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Options/ValidateNamedOptions.cs
+++ b/src/Microsoft.Extensions.Options/ValidateNamedOptions.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Options
+{
+
+    /// <summary>
+    /// Implementation of IValidateNamedOptions.
+    /// </summary>
+    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
+    public class ValidateNamedOptions<TOptions> : IValidateNamedOptions<TOptions> where TOptions : class
+    {
+        public ValidateNamedOptions() { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">The name of the options.</param>
+        /// <param name="action">The action to register.</param>
+        public ValidateNamedOptions(string name, Action<TOptions> action)
+        {
+            Name = name;
+            Action = action;
+        }
+
+        /// <summary>
+        /// The options name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The configuration action.
+        /// </summary>
+        public Action<TOptions> Action { get; set; }
+
+        /// <summary>
+        /// Invokes the registered validate Action if the name matches.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="options"></param>
+        public virtual void Validate(string name, TOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Null name is used to configure all named options.
+            if (Name == null || name == Name)
+            {
+                Action?.Invoke(options);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Options.Test/OptionsFactoryTests.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsFactoryTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Options.Tests
+{
+    public class OptionsFactoryTest
+    {
+        [Fact]
+        public void CanResolveNamedOptions()
+        {
+            var services = new ServiceCollection().AddOptions();
+
+            services.Configure<FakeOptions>("1", options =>
+            {
+                options.Message = "one";
+            });
+            services.Configure<FakeOptions>("2", options =>
+            {
+                options.Message = "two";
+            });
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Equal("one", option.Get("1").Message);
+            Assert.Equal("two", option.Get("2").Message);
+        }
+
+        [Fact]
+        public void FactoryValidatesOptions()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.Validate<FakeOptions>("1", options =>
+            {
+                if (string.IsNullOrEmpty(options.Message))
+                {
+                    throw new ArgumentNullException();
+                }
+            });
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Throws<ArgumentNullException>(() => option.Get("1"));
+        }
+
+        [Fact]
+        public void FactoryCanConfigureAllOptions()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.ConfigureAll<FakeOptions>(o => o.Message = "Default");
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Equal("Default", option.Get("1").Message);
+            Assert.Equal("Default", option.Get("2").Message);
+        }
+
+        [Fact]
+        public void FactoryCanValidateAllOptions()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.ValidateAll<FakeOptions>(options =>
+            {
+                if (string.IsNullOrEmpty(options.Message))
+                {
+                    throw new ArgumentNullException();
+                }
+            });
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Throws<ArgumentNullException>(() => option.Get("1"));
+            Assert.Throws<ArgumentNullException>(() => option.Get("2"));
+        }
+
+        [Fact]
+        public void FactoryConfigureAndValidateAllPlayWellTogether()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.ConfigureAll<FakeOptions>(o => o.Message = "Default");
+            services.Configure<FakeOptions>("NotDefault", o => o.Message = "NotDefault");
+            services.Configure<FakeOptions>("Throws", o => o.Message = null);
+            services.Validate<FakeOptions>("NotDefault", options =>
+            {
+                if (options.Message == "Default")
+                {
+                    throw new Exception();
+                }
+            });
+
+            services.ValidateAll<FakeOptions>(options =>
+            {
+                if (string.IsNullOrEmpty(options.Message))
+                {
+                    throw new ArgumentNullException();
+                }
+            });
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Equal("NotDefault", option.Get("NotDefault").Message);
+            Assert.Equal("Default", option.Get("Default").Message);
+            Assert.Throws<ArgumentNullException>(() => option.Get("Throws"));
+        }
+
+        [Fact]
+        public void FactoryConfiguresInRegistrationOrder()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.Configure<FakeOptions>("-", o => o.Message += "-");
+            services.ConfigureAll<FakeOptions>(o => o.Message += "A");
+            services.Configure<FakeOptions>("+", o => o.Message += "+");
+            services.ConfigureAll<FakeOptions>(o => o.Message += "B");
+            services.ConfigureAll<FakeOptions>(o => o.Message += "C");
+            services.Configure<FakeOptions>("+", o => o.Message += "+");
+            services.Configure<FakeOptions>("-", o => o.Message += "-");
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Equal("ABC", option.Get("1").Message);
+            Assert.Equal("A+BC+", option.Get("+").Message);
+            Assert.Equal("-ABC-", option.Get("-").Message);
+        }
+
+        [Fact]
+        public void FactoryValidatesInRegistrationOrder()
+        {
+            var services = new ServiceCollection().AddOptions();
+            services.Validate<FakeOptions>("-", o => o.Message += "-");
+            services.ValidateAll<FakeOptions>(o => o.Message += "A");
+            services.Validate<FakeOptions>("+", o => o.Message += "+");
+            services.ValidateAll<FakeOptions>(o => o.Message += "B");
+            services.ValidateAll<FakeOptions>(o => o.Message += "C");
+            services.Validate<FakeOptions>("+", o => o.Message += "+");
+            services.Validate<FakeOptions>("-", o => o.Message += "-");
+
+            var sp = services.BuildServiceProvider();
+            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            Assert.Equal("ABC", option.Get("1").Message);
+            Assert.Equal("A+BC+", option.Get("+").Message);
+            Assert.Equal("-ABC-", option.Get("-").Message);
+        }
+
+    }
+}

--- a/test/Microsoft.Extensions.Options.Test/OptionsServiceTests.cs
+++ b/test/Microsoft.Extensions.Options.Test/OptionsServiceTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Options.Tests
             });
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Equal("one", option.Get("1").Message);
             Assert.Equal("two", option.Get("2").Message);
         }
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Options.Tests
             });
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Throws<ArgumentNullException>(() => option.Get("1"));
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Options.Tests
             services.ConfigureAll<FakeOptions>(o => o.Message = "Default");
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Equal("Default", option.Get("1").Message);
             Assert.Equal("Default", option.Get("2").Message);
         }
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Options.Tests
             });
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Throws<ArgumentNullException>(() => option.Get("1"));
             Assert.Throws<ArgumentNullException>(() => option.Get("2"));
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Options.Tests
             });
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Equal("NotDefault", option.Get("NotDefault").Message);
             Assert.Equal("Default", option.Get("Default").Message);
             Assert.Throws<ArgumentNullException>(() => option.Get("Throws"));
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.Options.Tests
             services.Configure<FakeOptions>("-", o => o.Message += "-");
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Equal("ABC", option.Get("1").Message);
             Assert.Equal("A+BC+", option.Get("+").Message);
             Assert.Equal("-ABC-", option.Get("-").Message);
@@ -138,7 +138,7 @@ namespace Microsoft.Extensions.Options.Tests
             services.Validate<FakeOptions>("-", o => o.Message += "-");
 
             var sp = services.BuildServiceProvider();
-            var option = sp.GetRequiredService<IOptionsFactory<FakeOptions>>();
+            var option = sp.GetRequiredService<IOptionsService<FakeOptions>>();
             Assert.Equal("ABC", option.Get("1").Message);
             Assert.Equal("A+BC+", option.Get("+").Message);
             Assert.Equal("-ABC-", option.Get("-").Message);


### PR DESCRIPTION
Iteration 2:

`IOptionsFactory` is responsible for creating new options instances from the registered Configures
`IOptionsValidator` is responsible for validation of new options
`IOptionsCache` is in charge of cache semantics (and has an API that mimics ConcurrentDictionary
`IOptionsService` puts it all together

@ajcvickers @divega @davidfowl @DamianEdwards @Eilon @Tratcher 

