### PR TITLE
Update Travis macOS image to Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
 language: csharp
-sudo: required
+sudo: false
 dist: trusty
-addons:
-  apt:
-    packages:
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
-    - libunwind8
-    - zlib1g
 env:
   global:
-    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+    - DOTNET_CLI_TELEMETRY_OPTOUT=1
 mono: none
 os:
   - linux
   - osx
+osx_image: xcode8.2
 branches:
   only:
     - master
@@ -28,9 +20,3 @@ before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
   - ./build.sh
-notifications:
-  webhooks:
-    secure: "NG/u6ESPlM/TF2sg4uWYn/ufR5HEr+qZO3NsT8zzdKhkR1+AKazydK8jaf2Q39xtsmiNeZaSrzQ+movtYc9EzXZw+iHU94738rad0gTR5ht4CjpA3PvPxewe9aliOivfFXTKNNCrMANiarhrKDekS0jg2eplGr9QMHw1oGHM3pA="
-  on_success: always
-  on_failure: always
-  on_start: always


### PR DESCRIPTION
The important piece here is the "osx_image" part that upgrades to use macOS Sierra.

The other lines deleted is fluff we can cut from our images now that coreclr static links native dependencies.

Also, setting 'sudo: false' improves start up time by using Travis's container-based agents.