### PR TITLE
Obsolete wrapper methods

### DIFF
--- a/src/Microsoft.Extensions.Options/OptionsWrapper.cs
+++ b/src/Microsoft.Extensions.Options/OptionsWrapper.cs
@@ -22,16 +22,30 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         public TOptions Value { get; }
 
+        /// <summary>
+        /// This method is obsolete and will be removed in a future version.
+        /// </summary>
+        [Obsolete("This method is obsolete and will be removed in a future version.")]
         public void Add(string name, TOptions options)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// This method is obsolete and will be removed in a future version.
+        /// </summary>
+        /// <param name="name">This parameter is ignored.</param>
+        /// <returns>The <see cref="Value"/>.</returns>
+        [Obsolete("This method is obsolete and will be removed in a future version.")]
         public TOptions Get(string name)
         {
             return Value;
         }
 
+        /// <summary>
+        /// This method is obsolete and will be removed in a future version.
+        /// </summary>
+        [Obsolete("This method is obsolete and will be removed in a future version.")]
         public bool Remove(string name)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Also obsoletes `Get` which is also an orphaned method from IOptionsMonitor which OptionsWrapper does not implement.